### PR TITLE
[TASK] 공간 등록 API 게이트웨이 연동 (#28)

### DIFF
--- a/springProject/src/main/resources/application.yaml
+++ b/springProject/src/main/resources/application.yaml
@@ -45,6 +45,7 @@ spring:
                 - name: CircuitBreaker
                   args:
                     name: place-service
+                    fallbackUri: forward:/fallback/place
 
             # Room Info Service - 룸 정보 관리
             - id: room-info-service


### PR DESCRIPTION
## Summary
- place-info-service 라우트에 fallback URI 추가

## 확인 사항
- 라우팅: /api/v1/places/** → place-info-service ✅
- JWT 필터: X-User-Id, X-App-Type 헤더 전달 ✅
- Circuit Breaker: fallback URI 추가 ✅

Closes #28